### PR TITLE
[CHORE] 이슈 브랜치 자동 생성 추가

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -1,0 +1,122 @@
+name: Auto Branch
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-branch:
+    name: Create branch from issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build branch metadata
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          BASE_BRANCH: ${{ vars.DEV_BASE_BRANCH || 'dev' }}
+        run: |
+          python3 <<'PY' >> "$GITHUB_ENV"
+          import os
+          import re
+          import unicodedata
+
+          issue_number = os.environ["ISSUE_NUMBER"]
+          issue_title = os.environ["ISSUE_TITLE"]
+          base_branch = os.environ["BASE_BRANCH"]
+
+          type_map = {
+              "FEAT": "feat",
+              "FEATURE": "feat",
+              "FIX": "fix",
+              "BUG": "fix",
+              "HOTFIX": "hotfix",
+              "REFACTOR": "refactor",
+              "DESIGN": "design",
+              "STYLE": "style",
+              "DOCS": "docs",
+              "TEST": "test",
+              "CHORE": "chore",
+              "CI": "chore",
+          }
+
+          match = re.match(r"^\[([^\]]+)\]\s*(.*)$", issue_title)
+          raw_type = match.group(1).strip().upper() if match else "ISSUE"
+          title_body = match.group(2).strip() if match else issue_title
+          branch_type = type_map.get(raw_type, raw_type.lower())
+
+          normalized = unicodedata.normalize("NFKD", title_body).encode("ascii", "ignore").decode("ascii")
+          slug = re.sub(r"[^a-zA-Z0-9]+", "-", normalized).strip("-").lower()
+          slug = re.sub(r"-+", "-", slug)
+          slug = slug[:50].strip("-")
+
+          branch_name = f"{branch_type}/issue-{issue_number}"
+          if slug:
+              branch_name = f"{branch_type}/{slug}-{issue_number}"
+
+          print(f"BRANCH_NAME={branch_name}")
+          print(f"BASE_BRANCH={base_branch}")
+          PY
+
+      - name: Create linked branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue develop "$ISSUE_NUMBER" \
+            --name "$BRANCH_NAME" \
+            --base "$BASE_BRANCH" \
+            --repo "${{ github.repository }}"
+
+      - name: Comment on issue
+        uses: actions/github-script@v8
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          BASE_BRANCH: ${{ env.BASE_BRANCH }}
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const branchName = process.env.BRANCH_NAME;
+            const baseBranch = process.env.BASE_BRANCH;
+            const messages = [
+              { text: `코드 요정이 새 작업 브랜치를 만들어두었습니다. 이름은 \`${branchName}\` 입니다.`, weight: 5 },
+              { text: `로봇이 새 작업 구역을 준비했습니다. 브랜치는 \`${branchName}\` 입니다.`, weight: 4 },
+              { text: `작업 로켓이 발사되며 \`${branchName}\` 브랜치를 남겼습니다.`, weight: 4 },
+              { text: `마법책을 열자 \`${branchName}\` 브랜치가 튀어나왔습니다.`, weight: 3 },
+              { text: `마술사가 모자를 열자 \`${branchName}\` 브랜치가 나왔습니다.`, weight: 2 },
+              { text: `나무가 흔들리더니 \`${branchName}\` 브랜치가 하나 떨어졌습니다.`, weight: 1 }
+            ];
+
+            function pickWeighted(items) {
+              const total = items.reduce((sum, item) => sum + item.weight, 0);
+              let cursor = Math.random() * total;
+
+              for (const item of items) {
+                cursor -= item.weight;
+                if (cursor < 0) {
+                  return item.text;
+                }
+              }
+
+              return items[items.length - 1].text;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                pickWeighted(messages),
+                ``,
+                `- 브랜치: \`${branchName}\``,
+                `- 기준 브랜치: \`${baseBranch}\``
+              ].join("\n")
+            });


### PR DESCRIPTION
## 개요
Issue 생성 시 dev 기준 작업 브랜치를 자동 생성하고 이슈에 연결하는 GitHub Actions workflow를 추가했습니다.

- Issue opened 이벤트에서 자동 실행
- 기본 기준 브랜치는 `dev`
- `DEV_BASE_BRANCH` repo variable이 있으면 해당 값을 우선 사용
- 이슈 제목 prefix 기준으로 브랜치 타입 생성
- 예: `[CHORE] fastlane 배포 설정 정리` + 이슈 #123 → `chore/fastlane-123`
- 영문 slug를 만들 수 없는 제목은 `chore/issue-123` 형태로 fallback
- 생성된 브랜치와 기준 브랜치를 이슈 댓글로 안내

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 검증
- [x] `.github/workflows/auto-branch.yml` YAML 파싱 확인
- [x] 샘플 제목 기준 브랜치명 생성 확인
- [x] `git diff --check` 통과

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 남은 리스크
- 실제 브랜치 생성은 workflow가 main에 반영된 뒤 새 Issue 생성 이벤트에서 최종 확인해야 합니다.