### PR TITLE
[FIX] fastlane CI keychain 설정 추가

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,8 @@ platform :ios do
   # ----------------------------------------------------------
   desc "Push a new beta build to TestFlight"
   lane :beta do
+    setup_ci(provider: "github_actions") if ENV["CI"]
+
     # TODO: 새 프로젝트의 Bundle Identifier로 교체하세요.
     # - Tuist/ProjectDescriptionHelpers/AppEnv.swift와 fastlane/Matchfile의 app_identifier 목록과 동일해야 합니다.
     # - GitHub Actions에서는 TUIST_BUILD_CONFIG=DEV|BETA|RELEASE로 배포 대상을 고릅니다.


### PR DESCRIPTION
## 변경 요약
- GitHub Actions에서 fastlane이 임시 keychain을 사용하도록 setup_ci(provider: "github_actions")를 추가했습니다.

## 실패/중단 원인
- Fastlane Deploy run 26144630511은 Deploy with fastlane 단계에서 20분 이상 진행됐고, 로그상 _LottieStub.framework codesign 이후 멈춘 상태였습니다.
- CI의 login keychain 기반 codesign 접근 대기 가능성이 높아 run을 취소했습니다.

## 검증
- PR #85 체크 통과 후 dev에 머지 완료
- ruby -c fastlane/Fastfile
- bundle exec fastlane lanes
- git diff --check

## 관련 이슈
Related to: #80