### PR TITLE
[FIX] fastlane setup_ci provider 옵션 제거

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ platform :ios do
   # ----------------------------------------------------------
   desc "Push a new beta build to TestFlight"
   lane :beta do
-    setup_ci(provider: "github_actions") if ENV["CI"]
+    setup_ci if ENV["CI"]
 
     # TODO: 새 프로젝트의 Bundle Identifier로 교체하세요.
     # - Tuist/ProjectDescriptionHelpers/AppEnv.swift와 fastlane/Matchfile의 app_identifier 목록과 동일해야 합니다.


### PR DESCRIPTION
## 변경 요약
- fastlane setup_ci가 지원하지 않는 github_actions provider 값을 제거했습니다.
- CI 환경에서는 기본 setup_ci 동작으로 임시 keychain을 구성합니다.

## 실패 원인
- Fastlane Deploy run 26145716692에서 setup_ci(provider: "github_actions")가 지원되지 않는 provider로 실패했습니다.

## 검증
- ruby -c fastlane/Fastfile
- bundle exec fastlane lanes
- git diff --check

## 관련 이슈
Related to: #80