### PR TITLE
[FIX] fastlane 배포 Xcode 26 환경 고정

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -29,7 +29,7 @@ jobs:
   deploy:
     name: Deploy to TestFlight
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 60
 
     env:
@@ -58,6 +58,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Select Xcode 26
+        run: |
+          xcode_path="$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' | sort | tail -n 1)"
+
+          if [ -z "$xcode_path" ]; then
+            printf 'Xcode 26 is required but was not found.\n'
+            find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print
+            exit 1
+          fi
+
+          sudo xcode-select -s "$xcode_path/Contents/Developer"
+          xcodebuild -version
 
       - name: Validate deployment secrets
         run: |


### PR DESCRIPTION
## 변경 요약
- Fastlane Deploy GitHub Actions runner를 macos-26으로 고정했습니다.
- 배포 전에 Xcode 26 설치 경로를 선택하고 xcodebuild 버전을 로그에 남기도록 했습니다.

## 검증
- git diff --check

## 관련 이슈
Related to: #80