### PR TITLE
[FIX] fastlane 배포 stable Xcode 선택

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Select Xcode 26
         run: |
-          xcode_path="$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' | sort | tail -n 1)"
+          xcode_path="$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' ! -name '*beta*' | sort | tail -n 1)"
 
           if [ -z "$xcode_path" ]; then
-            printf 'Xcode 26 is required but was not found.\n'
+            printf 'Stable Xcode 26 is required but was not found.\n'
             find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print
             exit 1
           fi


### PR DESCRIPTION
## 변경 요약
- macos-26 runner에서 Xcode 26 beta 앱을 선택하지 않도록 stable Xcode만 필터링했습니다.
- stable Xcode 26이 없을 때 설치된 Xcode 목록을 출력하고 실패하도록 했습니다.

## 검증
- git diff --check

## 관련 이슈
Related to: #80