### PR TITLE
[FIX] fastlane 배포 stable Xcode 선택 반영

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -61,10 +61,10 @@ jobs:
 
       - name: Select Xcode 26
         run: |
-          xcode_path="$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' | sort | tail -n 1)"
+          xcode_path="$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' ! -name '*beta*' | sort | tail -n 1)"
 
           if [ -z "$xcode_path" ]; then
-            printf 'Xcode 26 is required but was not found.\n'
+            printf 'Stable Xcode 26 is required but was not found.\n'
             find /Applications -maxdepth 1 -type d -name 'Xcode*.app' -print
             exit 1
           fi


### PR DESCRIPTION
## 변경 요약
- macos-26 runner에서 Xcode 26 beta 대신 stable Xcode 26을 선택하도록 반영했습니다.

## 검증
- PR #91 checks 통과
- git diff --check

## 관련 이슈
Related to: #80