### PR TITLE
[CHORE] fastlane 배포 흐름 분리

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -3,11 +3,20 @@ name: Fastlane Deploy
 on:
   pull_request:
     branches:
+      - dev
       - main
     types:
       - closed
   workflow_dispatch:
     inputs:
+      deploy_target:
+        description: "Deployment target"
+        required: true
+        default: "testflight"
+        type: choice
+        options:
+          - testflight
+          - app_store_prepare
       build_config:
         description: "Tuist build config to deploy"
         required: true
@@ -27,12 +36,13 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy to TestFlight
+    name: Deploy app
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: macos-26
     timeout-minutes: 60
 
     env:
+      DEPLOY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_target || (github.base_ref == 'dev' && 'testflight' || 'app_store_prepare') }}
       TUIST_BUILD_CONFIG: ${{ github.event_name == 'workflow_dispatch' && inputs.build_config || 'RELEASE' }}
       API_BASE_URL: ${{ secrets.API_BASE_URL }}
       ID_KEY: ${{ secrets.ID_KEY }}
@@ -78,6 +88,8 @@ jobs:
             "ID_KEY"
             "SECRET_KEY"
             "NAVER_MAP_CLIENT_ID"
+            "APP_IDENTIFIER_BETA"
+            "APP_IDENTIFIER_RELEASE"
             "FASTLANE_APPLE_ID"
             "FASTLANE_ITC_TEAM_ID"
             "DEVELOPMENT_TEAM"
@@ -142,4 +154,16 @@ jobs:
           TUIST_ROOT_DIR="$PWD" TUIST_BUILD_CONFIG="$(echo "$TUIST_BUILD_CONFIG" | tr '[:upper:]' '[:lower:]')" tuist generate --no-open
 
       - name: Deploy with fastlane
-        run: bundle exec fastlane ios beta
+        run: |
+          case "$DEPLOY_TARGET" in
+            testflight)
+              bundle exec fastlane ios beta
+              ;;
+            app_store_prepare)
+              bundle exec fastlane ios prepare_app_store
+              ;;
+            *)
+              printf 'Unsupported DEPLOY_TARGET: %s\n' "$DEPLOY_TARGET"
+              exit 1
+              ;;
+          esac

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,19 +21,10 @@ default_platform(:ios)
 # ------------------------------------------------------------
 platform :ios do
 
-  # ----------------------------------------------------------
-  # Lane: beta
-  # - 역할: TestFlight로 베타 빌드 업로드
-  # - 트리거: 로컬/CI에서 `fastlane beta` 실행
-  # ----------------------------------------------------------
-  desc "Push a new beta build to TestFlight"
-  lane :beta do
+  private_lane :archive_app do |options|
     setup_ci if ENV["CI"]
 
-    # TODO: 새 프로젝트의 Bundle Identifier로 교체하세요.
-    # - Tuist/ProjectDescriptionHelpers/AppEnv.swift와 fastlane/Matchfile의 app_identifier 목록과 동일해야 합니다.
-    # - GitHub Actions에서는 TUIST_BUILD_CONFIG=DEV|BETA|RELEASE로 배포 대상을 고릅니다.
-    build_config = (ENV["TUIST_BUILD_CONFIG"] || "BETA").upcase
+    build_config = (options[:build_config] || ENV["TUIST_BUILD_CONFIG"] || "BETA").upcase
     case build_config
     when "DEV"
       bundle_id = ENV["APP_IDENTIFIER_DEV"] || "com.kibwa.BobPT.dev"
@@ -131,6 +122,22 @@ platform :ios do
       }
     )
 
+    {
+      api_key: api_key,
+      bundle_id: bundle_id,
+      build_number: time_build
+    }
+  end
+
+  # ----------------------------------------------------------
+  # Lane: beta
+  # - 역할: TestFlight로 베타 빌드 업로드
+  # - 트리거: dev 머지 또는 로컬/CI에서 `fastlane ios beta` 실행
+  # ----------------------------------------------------------
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    archive_context = archive_app(build_config: ENV["TUIST_BUILD_CONFIG"] || "BETA")
+
     # --------------------------------------------------------
     # 5) TestFlight 업로드
     #    - api_key: 위에서 생성한 App Store Connect API Key 객체
@@ -140,10 +147,32 @@ platform :ios do
     #      changelog: "..."                       → 빌드 노트(커밋 메시지 등)
     # --------------------------------------------------------
     upload_to_testflight(
-      api_key: api_key,
+      api_key: archive_context[:api_key],
       skip_waiting_for_build_processing: true
       #, distribute_external: false
       #, changelog: `git log -1 --pretty=%B`.strip
+    )
+  end
+
+  # ----------------------------------------------------------
+  # Lane: prepare_app_store
+  # - 역할: RELEASE 빌드를 App Store Connect에 업로드
+  # - 심사 제출은 하지 않고, App Store Connect에서 수동으로 추가 정보를 입력할 수 있게 준비
+  # - 트리거: main 머지 또는 로컬/CI에서 `fastlane ios prepare_app_store` 실행
+  # ----------------------------------------------------------
+  desc "Upload a release build to App Store Connect without submitting for review"
+  lane :prepare_app_store do
+    archive_context = archive_app(build_config: "RELEASE")
+
+    upload_to_app_store(
+      api_key: archive_context[:api_key],
+      app_identifier: archive_context[:bundle_id],
+      submit_for_review: false,
+      skip_metadata: true,
+      skip_screenshots: true,
+      force: true,
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false
     )
   end
 end


### PR DESCRIPTION
## 변경 요약
- dev 머지 시 TestFlight 배포 lane을 실행하도록 workflow를 분기했습니다.
- main 머지 시 심사 제출 없이 App Store Connect 빌드 준비 lane을 실행하도록 분기했습니다.
- Fastfile의 공통 archive/sign/build 로직을 private lane으로 분리했습니다.

## 검증
- ruby -c fastlane/Fastfile
- workflow YAML 파싱
- git diff --check
- bundle exec fastlane lanes