### PR TITLE
[CHORE] GitHub Actions Node 24 실행 설정

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -34,6 +34,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
## 변경 요약
- workflow 전역에 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true를 추가했습니다.
- jdx/mise-action@v3에서도 유지되던 Node.js 20 deprecation annotation을 제거하기 위한 설정입니다.

## 검증
- workflow YAML 파싱
- git diff --check

## 관련 이슈
Related to: #97