### PR TITLE
[CHORE] mise 설정을 쉘 기반으로 전환

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -34,9 +34,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   deploy:
     name: Deploy app
@@ -125,7 +122,12 @@ jobs:
           bundler-cache: true
 
       - name: Set up Tuist
-        uses: jdx/mise-action@v3
+        run: |
+          brew install mise
+          echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"
+          echo "MISE_YES=1" >> "$GITHUB_ENV"
+          echo "MISE_TRUSTED_CONFIG_PATHS=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          MISE_YES=1 MISE_TRUSTED_CONFIG_PATHS="$GITHUB_WORKSPACE" mise install
 
       - name: Set up App Store Connect API key
         run: |


### PR DESCRIPTION
## 변경 요약
- Node 20 대상 jdx/mise-action 사용을 제거했습니다.
- Homebrew로 mise를 설치하고 mise.toml 기준으로 Tuist를 설치하도록 변경했습니다.
- mise shims와 trust 환경을 GitHub Actions 환경에 등록했습니다.

## 검증
- workflow YAML 파싱
- git diff --check

## 관련 이슈
Related to: #97