### PR TITLE
UI/UX 예외 처리 고도화

### DIFF
--- a/Projects/App/BobPT/Project.swift
+++ b/Projects/App/BobPT/Project.swift
@@ -20,6 +20,7 @@ let appTarget: Target = .target(
     ],
     privacyManifest: .bobPT
   ),
+  entitlements: Entitlements.BobPT.app,
   dependencies: [
     .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
     .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),

--- a/Projects/App/BobPT/Project.swift
+++ b/Projects/App/BobPT/Project.swift
@@ -24,6 +24,7 @@ let appTarget: Target = .target(
   dependencies: [
     .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
     .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),
+    .project(target: "FeedbackUI", path: "../../Shared/FeedbackUI"),
     .project(target: "RecommendationFeature", path: "../../Feature/RecommendationFeature"),
     .project(target: "HistoryFeature", path: "../../Feature/HistoryFeature"),
     .project(target: "SettingsFeature", path: "../../Feature/SettingsFeature")

--- a/Projects/App/BobPT/Sources/RootTabView.swift
+++ b/Projects/App/BobPT/Sources/RootTabView.swift
@@ -15,25 +15,27 @@ import SettingsFeature
 struct RootTabView: View {
     @AppStorage(DesignSystem.AppearanceMode.storageKey) private var appearanceMode = DesignSystem.AppearanceMode.system
     @StateObject private var selectedStore = SelectedRestaurantStore()
+    @StateObject private var authStore = AuthSessionStore()
+    @State private var toastMessage: String?
 
     var body: some View {
         TabView {
             NavigationStack {
-                MainView(selectedStore: selectedStore)
+                MainView(selectedStore: selectedStore, authStore: authStore)
             }
             .tabItem {
                 Label("홈", systemImage: "house.fill")
             }
 
             NavigationStack {
-                SelectedListView(store: selectedStore)
+                SelectedListView(store: selectedStore, authStore: authStore)
             }
             .tabItem {
                 Label("기록", systemImage: "list.bullet")
             }
 
             NavigationStack {
-                SettingsView()
+                SettingsView(authStore: authStore)
             }
             .tabItem {
                 Label("세팅", systemImage: "gearshape.fill")
@@ -43,5 +45,17 @@ struct RootTabView: View {
         .toolbarBackground(DesignSystem.Colors.surface, for: .tabBar)
         .toolbarBackground(.visible, for: .tabBar)
         .preferredColorScheme(appearanceMode.colorScheme)
+        .bobPTToast(message: $toastMessage)
+        .task {
+            await authStore.validateSession()
+        }
+        .onChange(of: authStore.feedbackMessage) { message in
+            guard let message else {
+                return
+            }
+
+            toastMessage = message
+            authStore.feedbackMessage = nil
+        }
     }
 }

--- a/Projects/App/BobPT/Sources/RootTabView.swift
+++ b/Projects/App/BobPT/Sources/RootTabView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import BobPTCore
 import DesignSystem
+import FeedbackUI
 import HistoryFeature
 import RecommendationFeature
 import SettingsFeature
@@ -56,6 +57,13 @@ struct RootTabView: View {
 
             toastMessage = message
             authStore.feedbackMessage = nil
+        }
+        .onChange(of: authStore.isSignedIn) { isSignedIn in
+            guard isSignedIn else {
+                return
+            }
+
+            toastMessage = nil
         }
     }
 }

--- a/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
+++ b/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
@@ -1,0 +1,128 @@
+//
+//  AuthSessionStore.swift
+//  BobPT
+//
+//  Created by Codex on 5/21/26.
+//
+
+import Foundation
+import Security
+
+@MainActor
+public final class AuthSessionStore: ObservableObject {
+    @Published public private(set) var session: AuthSession?
+    @Published public var feedbackMessage: String?
+
+    private let backendService: BobPTBackendService
+    private let keychain = AuthKeychainStore()
+
+    public var isSignedIn: Bool {
+        session != nil
+    }
+
+    public var accessToken: String? {
+        session?.accessToken
+    }
+
+    public init(backendService: BobPTBackendService = BobPTBackendService()) {
+        self.backendService = backendService
+        session = keychain.load()
+    }
+
+    public func validateSession() async {
+        guard let accessToken else {
+            return
+        }
+
+        do {
+            let user = try await backendService.fetchCurrentUser(accessToken: accessToken)
+            guard let currentSession = session else {
+                return
+            }
+
+            let updatedSession = AuthSession(
+                accessToken: currentSession.accessToken,
+                tokenType: currentSession.tokenType,
+                expiresIn: currentSession.expiresIn,
+                user: user
+            )
+            session = updatedSession
+            keychain.save(updatedSession)
+        } catch let error as BackendServiceError {
+            handleSessionValidationError(error)
+        } catch {
+            feedbackMessage = "로그인 상태를 확인하지 못했습니다."
+        }
+    }
+
+    public func signInWithApple(identityToken: String, fullName: String?) async throws {
+        let session = try await backendService.signInWithApple(identityToken: identityToken, fullName: fullName)
+        self.session = session
+        keychain.save(session)
+    }
+
+    public func signOut(message: String? = nil) {
+        session = nil
+        keychain.delete()
+        feedbackMessage = message
+    }
+
+    private func handleSessionValidationError(_ error: BackendServiceError) {
+        switch error {
+        case .unauthorized:
+            signOut(message: "로그인이 만료되어 로그아웃되었습니다.")
+        case .missingBaseURL:
+            feedbackMessage = error.errorDescription
+        case .networkUnavailable, .serverUnavailable:
+            feedbackMessage = error.errorDescription
+        case .forbidden, .notFound, .invalidResponse:
+            feedbackMessage = "로그인 상태를 확인하지 못했습니다."
+        }
+    }
+}
+
+private struct AuthKeychainStore {
+    private let service = "\(Bundle.main.bundleIdentifier ?? "com.kibwa.BobPT").auth"
+    private let account = "session"
+
+    func load() -> AuthSession? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        guard status == errSecSuccess,
+              let data = item as? Data else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(AuthSession.self, from: data)
+    }
+
+    func save(_ session: AuthSession) {
+        guard let data = try? JSONEncoder().encode(session) else {
+            return
+        }
+
+        delete()
+
+        var query = baseQuery
+        query[kSecValueData as String] = data
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func delete() {
+        SecItemDelete(baseQuery as CFDictionary)
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+    }
+}

--- a/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
+++ b/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
@@ -1,0 +1,342 @@
+//
+//  BobPTBackendService.swift
+//  BobPT
+//
+//  Created by Codex on 5/21/26.
+//
+
+import Alamofire
+import Foundation
+import BobPTDomain
+import Utils
+
+public struct BobPTBackendService: Sendable {
+    public init() {}
+
+    public func saveRecommendation(
+        restaurants: [Restaurant],
+        foodCategories: [FoodCategory],
+        location: String,
+        latitude: Double?,
+        longitude: Double?,
+        accessToken: String?
+    ) async throws {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/recommendations")
+        let body = RecommendationSaveRequest(
+            location: location,
+            foodCategories: foodCategories.map(\.rawValue),
+            latitude: latitude,
+            longitude: longitude,
+            restaurants: restaurants.map { RestaurantPayload(restaurant: $0) }
+        )
+
+        try await withCheckedThrowingContinuation { continuation in
+            AF.request(
+                endpoint,
+                method: .post,
+                parameters: body,
+                encoder: JSONParameterEncoder.default,
+                headers: authorizationHeaders(accessToken: accessToken)
+            )
+                .validate(statusCode: 200..<300)
+                .response { response in
+                    switch response.result {
+                    case .success:
+                        continuation.resume()
+                    case .failure(let error):
+                        continuation.resume(throwing: error.backendServiceError)
+                    }
+                }
+        }
+    }
+
+    public func signInWithApple(identityToken: String, fullName: String?) async throws -> AuthSession {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/apple")
+        let body = AppleLoginRequest(identityToken: identityToken, fullName: fullName)
+        let response: APIResponse<AuthSession> = try await requestDecodable(
+            endpoint,
+            method: .post,
+            parameters: body,
+            headers: nil
+        )
+
+        return response.data
+    }
+
+    public func fetchSelections(accessToken: String) async throws -> [SavedRestaurant] {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/selections")
+        let response: APIResponse<[SelectionResponse]> = try await requestDecodable(
+            endpoint,
+            method: .get,
+            parameters: Optional<EmptyRequest>.none,
+            headers: authorizationHeaders(accessToken: accessToken)
+        )
+
+        return response.data.map(\.savedRestaurant)
+    }
+
+    public func fetchCurrentUser(accessToken: String) async throws -> AuthUser {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/me")
+        let response: APIResponse<AuthUser> = try await requestDecodable(
+            endpoint,
+            method: .get,
+            parameters: Optional<EmptyRequest>.none,
+            headers: authorizationHeaders(accessToken: accessToken)
+        )
+
+        return response.data
+    }
+
+    public func saveSelection(_ restaurant: Restaurant, accessToken: String) async throws {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/selections")
+        let body = RestaurantPayload(restaurant: restaurant)
+
+        try await withCheckedThrowingContinuation { continuation in
+            AF.request(
+                endpoint,
+                method: .post,
+                parameters: body,
+                encoder: JSONParameterEncoder.default,
+                headers: authorizationHeaders(accessToken: accessToken)
+            )
+            .validate(statusCode: 200..<300)
+            .response { response in
+                switch response.result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error.backendServiceError)
+                }
+            }
+        }
+    }
+
+    public func deleteSelection(id: String, accessToken: String) async throws {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/selections/\(id)")
+
+        try await withCheckedThrowingContinuation { continuation in
+            AF.request(endpoint, method: .delete, headers: authorizationHeaders(accessToken: accessToken))
+                .validate(statusCode: 200..<300)
+                .response { response in
+                    switch response.result {
+                    case .success:
+                        continuation.resume()
+                    case .failure(let error):
+                        continuation.resume(throwing: error.backendServiceError)
+                    }
+                }
+        }
+    }
+
+    private func requestDecodable<T: Decodable, P: Encodable>(
+        _ url: URL,
+        method: HTTPMethod,
+        parameters: P?,
+        headers: HTTPHeaders?
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            AF.request(url, method: method, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
+                .validate(statusCode: 200..<300)
+                .responseDecodable(of: T.self) { response in
+                    switch response.result {
+                    case .success(let value):
+                        continuation.resume(returning: value)
+                    case .failure(let error):
+                        continuation.resume(throwing: error.backendServiceError)
+                    }
+                }
+        }
+    }
+}
+
+public enum BackendServiceError: LocalizedError {
+    case missingBaseURL
+    case unauthorized
+    case forbidden
+    case notFound
+    case serverUnavailable
+    case networkUnavailable
+    case invalidResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingBaseURL:
+            return "API 주소가 설정되어 있지 않습니다."
+        case .unauthorized:
+            return "로그인이 만료되었습니다."
+        case .forbidden:
+            return "요청 권한이 없습니다."
+        case .notFound:
+            return "요청한 정보를 찾지 못했습니다."
+        case .serverUnavailable:
+            return "서버가 응답하지 않습니다. 잠시 후 다시 시도해주세요."
+        case .networkUnavailable:
+            return "네트워크 연결을 확인해주세요."
+        case .invalidResponse:
+            return "서버 응답을 처리하지 못했습니다."
+        }
+    }
+}
+
+public struct AuthSession: Codable, Sendable {
+    public let accessToken: String
+    public let tokenType: String
+    public let expiresIn: Int
+    public let user: AuthUser
+}
+
+public struct AuthUser: Codable, Identifiable, Sendable {
+    public let id: String
+    public let email: String?
+    public let displayName: String?
+}
+
+public struct SavedRestaurant: Identifiable, Sendable {
+    public let id: String
+    public let restaurant: Restaurant
+}
+
+private struct APIResponse<T: Decodable>: Decodable {
+    let data: T
+}
+
+private struct EmptyRequest: Encodable {}
+
+private struct AppleLoginRequest: Encodable, Sendable {
+    let identityToken: String
+    let fullName: String?
+}
+
+private struct RecommendationSaveRequest: Encodable, Sendable {
+    let location: String
+    let foodCategories: [String]
+    let latitude: Double?
+    let longitude: Double?
+    let restaurants: [RestaurantPayload]
+}
+
+private struct RestaurantPayload: Encodable, Sendable {
+    let title: String
+    let link: String?
+    let category: String
+    let description: String?
+    let address: String
+    let mapx: String
+    let mapy: String
+    let imageName: String?
+
+    init(restaurant: Restaurant) {
+        title = restaurant.title
+        link = restaurant.link.isEmpty ? nil : restaurant.link
+        category = restaurant.category
+        description = restaurant.description.isEmpty ? nil : restaurant.description
+        address = restaurant.address
+        mapx = restaurant.mapx
+        mapy = restaurant.mapy
+        imageName = restaurant.imageString
+    }
+}
+
+private struct SelectionResponse: Decodable {
+    let id: String
+    let title: String
+    let link: String?
+    let category: String
+    let description: String?
+    let address: String
+    let mapx: String
+    let mapy: String
+    let imageName: String?
+    let selectedAt: String
+
+    var savedRestaurant: SavedRestaurant {
+        SavedRestaurant(
+            id: id,
+            restaurant: Restaurant(
+                title: title,
+                link: link ?? "",
+                category: category,
+                description: description ?? "",
+                address: address,
+                mapx: mapx,
+                mapy: mapy,
+                date: selectedAt,
+                imageString: imageName
+            )
+        )
+    }
+}
+
+private func authorizationHeaders(accessToken: String?) -> HTTPHeaders? {
+    guard let accessToken, !accessToken.isEmpty else {
+        return nil
+    }
+
+    return ["Authorization": "Bearer \(accessToken)"]
+}
+
+private extension AFError {
+    var backendServiceError: Error {
+        if let responseCode {
+            switch responseCode {
+            case 401:
+                return BackendServiceError.unauthorized
+            case 403:
+                return BackendServiceError.forbidden
+            case 404:
+                return BackendServiceError.notFound
+            case 500...599:
+                return BackendServiceError.serverUnavailable
+            default:
+                break
+            }
+        }
+
+        if case .sessionTaskFailed(let error) = self,
+           (error as? URLError) != nil {
+            return BackendServiceError.networkUnavailable
+        }
+
+        if case .responseSerializationFailed = self {
+            return BackendServiceError.invalidResponse
+        }
+
+        return self
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var validBaseURL: URL? {
+        guard let value = self?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              !value.hasPrefix("$(") else {
+            return nil
+        }
+
+        return URL(string: value)
+    }
+}

--- a/Projects/Feature/HistoryFeature/Project.swift
+++ b/Projects/Feature/HistoryFeature/Project.swift
@@ -18,6 +18,7 @@ let target: Target = .target(
     .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
     .project(target: "BobPTDomain", path: "../../Domain/BobPTDomain"),
     .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),
+    .project(target: "FeedbackUI", path: "../../Shared/FeedbackUI"),
     .project(target: "Utils", path: "../../Shared/Utils")
   ],
   settings: .targetSettings(product: .staticFramework)

--- a/Projects/Feature/HistoryFeature/Sources/SelectedListView.swift
+++ b/Projects/Feature/HistoryFeature/Sources/SelectedListView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import BobPTCore
 import BobPTDomain
 import DesignSystem
+import FeedbackUI
 import Utils
 
 public struct SelectedListView: View {
@@ -76,14 +77,7 @@ public struct SelectedListView: View {
         .toolbar {
             EditButton()
         }
-        .alert("알림", isPresented: Binding(
-            get: { alertMessage != nil },
-            set: { if !$0 { alertMessage = nil } }
-        )) {
-            Button("확인", role: .cancel) {}
-        } message: {
-            Text(alertMessage ?? "")
-        }
+        .bobPTAlert(message: $alertMessage)
         .bobPTToast(message: $toastMessage)
         .onAppear {
             load()

--- a/Projects/Feature/HistoryFeature/Sources/SelectedListView.swift
+++ b/Projects/Feature/HistoryFeature/Sources/SelectedListView.swift
@@ -13,14 +13,22 @@ import Utils
 
 public struct SelectedListView: View {
     @ObservedObject var store: SelectedRestaurantStore
+    @ObservedObject var authStore: AuthSessionStore
+    @State private var remoteSelections: [SavedRestaurant] = []
+    @State private var isLoading = false
+    @State private var alertMessage: String?
+    @State private var toastMessage: String?
 
-    public init(store: SelectedRestaurantStore) {
+    private let backendService = BobPTBackendService()
+
+    public init(store: SelectedRestaurantStore, authStore: AuthSessionStore) {
         self.store = store
+        self.authStore = authStore
     }
 
     public var body: some View {
         Group {
-            if store.restaurants.isEmpty {
+            if displayedRestaurants.isEmpty {
                 VStack(spacing: 18) {
                     Image("RobotForce")
                         .resizable()
@@ -30,23 +38,26 @@ public struct SelectedListView: View {
                     Text("저장된 추천 장소가 없습니다.")
                         .font(.headline)
                         .foregroundStyle(DesignSystem.Colors.secondaryText)
+                    if isLoading {
+                        ProgressView()
+                    }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(DesignSystem.Colors.background)
             } else {
                 List {
-                    ForEach(store.restaurants) { restaurant in
+                    ForEach(displayedRestaurants) { item in
                         HStack(spacing: 14) {
-                            Image(restaurant.imageString ?? "Default")
+                            Image(item.restaurant.imageString ?? "Default")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 64, height: 54)
 
                             VStack(alignment: .leading, spacing: 6) {
-                                Text(restaurant.title.htmlEscaped)
+                                Text(item.restaurant.title.htmlEscaped)
                                     .font(.headline)
                                     .lineLimit(1)
-                                Text(restaurant.date.htmlEscaped)
+                                Text(item.restaurant.date.htmlEscaped)
                                     .font(.subheadline)
                                     .foregroundStyle(DesignSystem.Colors.secondaryText)
                             }
@@ -54,7 +65,7 @@ public struct SelectedListView: View {
                         .padding(.vertical, 8)
                         .listRowBackground(DesignSystem.Colors.surface)
                     }
-                    .onDelete(perform: store.delete)
+                    .onDelete(perform: delete)
                 }
                 .scrollContentBackground(.hidden)
                 .background(DesignSystem.Colors.background)
@@ -65,8 +76,93 @@ public struct SelectedListView: View {
         .toolbar {
             EditButton()
         }
+        .alert("알림", isPresented: Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text(alertMessage ?? "")
+        }
+        .bobPTToast(message: $toastMessage)
         .onAppear {
-            store.load()
+            load()
+        }
+        .onChange(of: authStore.isSignedIn) { _ in
+            load()
         }
     }
+
+    private var displayedRestaurants: [DisplayedRestaurant] {
+        if authStore.isSignedIn {
+            return remoteSelections.map { DisplayedRestaurant(id: $0.id, restaurant: $0.restaurant) }
+        }
+
+        return store.restaurants.map { DisplayedRestaurant(id: $0.id, restaurant: $0) }
+    }
+
+    private func load() {
+        if let accessToken = authStore.accessToken {
+            Task {
+                await loadRemote(accessToken: accessToken)
+            }
+        } else {
+            store.load()
+            remoteSelections = []
+        }
+    }
+
+    private func loadRemote(accessToken: String) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            remoteSelections = try await backendService.fetchSelections(accessToken: accessToken)
+        } catch BackendServiceError.unauthorized {
+            authStore.signOut(message: "로그인이 만료되어 기기에 저장된 기록을 표시합니다.")
+            store.load()
+            remoteSelections = []
+        } catch BackendServiceError.missingBaseURL {
+            store.load()
+            remoteSelections = []
+            toastMessage = "API 주소가 설정되지 않아 기기에 저장된 기록을 표시합니다."
+        } catch {
+            alertMessage = "서버 기록을 불러오지 못했습니다."
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        if let accessToken = authStore.accessToken {
+            let targets = offsets.compactMap { remoteSelections.indices.contains($0) ? remoteSelections[$0] : nil }
+            let previousSelections = remoteSelections
+            remoteSelections.remove(atOffsets: offsets)
+            Task {
+                for target in targets {
+                    do {
+                        try await backendService.deleteSelection(id: target.id, accessToken: accessToken)
+                    } catch BackendServiceError.unauthorized {
+                        await MainActor.run {
+                            authStore.signOut(message: "로그인이 만료되어 서버 기록 삭제를 완료하지 못했습니다.")
+                            store.load()
+                            remoteSelections = []
+                        }
+                        return
+                    } catch {
+                        await MainActor.run {
+                            remoteSelections = previousSelections
+                            toastMessage = "서버 기록을 삭제하지 못했습니다."
+                        }
+                        return
+                    }
+                }
+            }
+        } else {
+            store.delete(at: offsets)
+        }
+    }
+}
+
+private struct DisplayedRestaurant: Identifiable {
+    let id: String
+    let restaurant: Restaurant
 }

--- a/Projects/Feature/RecommendationFeature/Sources/MainView.swift
+++ b/Projects/Feature/RecommendationFeature/Sources/MainView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import BobPTCore
 import BobPTDomain
 import DesignSystem
+import FeedbackUI
 
 public struct MainView: View {
     @StateObject private var locationProvider = LocationProvider()
@@ -57,14 +58,7 @@ public struct MainView: View {
                     ResultView(result: recommendationResult, store: selectedStore, authStore: authStore)
                 }
             }
-            .alert("알림", isPresented: Binding(
-                get: { alertMessage != nil },
-                set: { if !$0 { alertMessage = nil } }
-            )) {
-                Button("확인", role: .cancel) {}
-            } message: {
-                Text(alertMessage ?? "")
-            }
+            .bobPTAlert(message: $alertMessage)
             .disabled(isSearching)
             .task {
                 selectedStore.load()
@@ -85,14 +79,6 @@ public struct MainView: View {
 
                 toastMessage = message
                 locationProvider.clearErrorMessage()
-            }
-            .onChange(of: authStore.feedbackMessage) { message in
-                guard let message else {
-                    return
-                }
-
-                toastMessage = message
-                authStore.feedbackMessage = nil
             }
             .bobPTToast(message: $toastMessage)
 

--- a/Projects/Feature/RecommendationFeature/Sources/MainView.swift
+++ b/Projects/Feature/RecommendationFeature/Sources/MainView.swift
@@ -13,19 +13,23 @@ import DesignSystem
 public struct MainView: View {
     @StateObject private var locationProvider = LocationProvider()
     @ObservedObject private var selectedStore: SelectedRestaurantStore
+    @ObservedObject private var authStore: AuthSessionStore
     @State private var selectedFoods: Set<FoodCategory> = []
     @State private var recommendationResult: RecommendationResult?
     @State private var isSearching = false
     @State private var alertMessage: String?
+    @State private var toastMessage: String?
     @State private var showsLaunchAnimation = true
     @State private var launchAnimationDidFinish = false
     @State private var hasRequestedInitialLocation = false
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 14), count: 3)
     private let searchService = NaverSearchService()
+    private let backendService = BobPTBackendService()
 
-    public init(selectedStore: SelectedRestaurantStore) {
+    public init(selectedStore: SelectedRestaurantStore, authStore: AuthSessionStore) {
         self.selectedStore = selectedStore
+        self.authStore = authStore
     }
 
     public var body: some View {
@@ -50,7 +54,7 @@ public struct MainView: View {
                 }
             )) {
                 if let recommendationResult {
-                    ResultView(result: recommendationResult, store: selectedStore)
+                    ResultView(result: recommendationResult, store: selectedStore, authStore: authStore)
                 }
             }
             .alert("알림", isPresented: Binding(
@@ -79,9 +83,18 @@ public struct MainView: View {
                     return
                 }
 
-                alertMessage = message
+                toastMessage = message
                 locationProvider.clearErrorMessage()
             }
+            .onChange(of: authStore.feedbackMessage) { message in
+                guard let message else {
+                    return
+                }
+
+                toastMessage = message
+                authStore.feedbackMessage = nil
+            }
+            .bobPTToast(message: $toastMessage)
 
             if isSearching {
                 ProgressView("음식점을 찾는 중")
@@ -189,6 +202,23 @@ public struct MainView: View {
             guard !restaurants.isEmpty else {
                 alertMessage = "추천 가능한 음식점을 찾지 못했습니다."
                 return
+            }
+
+            if authStore.isSignedIn {
+                do {
+                    try await backendService.saveRecommendation(
+                        restaurants: restaurants,
+                        foodCategories: Array(selectedFoods),
+                        location: locationName,
+                        latitude: locationProvider.latitude,
+                        longitude: locationProvider.longitude,
+                        accessToken: authStore.accessToken
+                    )
+                } catch BackendServiceError.unauthorized {
+                    authStore.signOut(message: "로그인이 만료되어 추천 기록은 기기에만 표시됩니다.")
+                } catch {
+                    toastMessage = "추천 기록을 서버에 저장하지 못했습니다. 추천 결과는 계속 확인할 수 있습니다."
+                }
             }
 
             recommendationResult = RecommendationResult(

--- a/Projects/Feature/RecommendationFeature/Sources/MapScreen.swift
+++ b/Projects/Feature/RecommendationFeature/Sources/MapScreen.swift
@@ -10,6 +10,7 @@ import NMapsMap
 import SwiftUI
 import BobPTDomain
 import DesignSystem
+import FeedbackUI
 import Utils
 
 struct MapScreen: View {
@@ -87,14 +88,7 @@ struct MapScreen: View {
         .background(DesignSystem.Colors.background.ignoresSafeArea())
         .navigationTitle("지도")
         .navigationBarTitleDisplayMode(.inline)
-        .alert("알림", isPresented: Binding(
-            get: { alertMessage != nil },
-            set: { if !$0 { alertMessage = nil } }
-        )) {
-            Button("확인", role: .cancel) {}
-        } message: {
-            Text(alertMessage ?? "")
-        }
+        .bobPTAlert(message: $alertMessage)
     }
 
     private var destinationCoordinate: CLLocationCoordinate2D? {

--- a/Projects/Feature/RecommendationFeature/Sources/ResultView.swift
+++ b/Projects/Feature/RecommendationFeature/Sources/ResultView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import BobPTCore
 import BobPTDomain
 import DesignSystem
+import FeedbackUI
 import Utils
 
 struct ResultView: View {

--- a/Projects/Feature/RecommendationFeature/Sources/ResultView.swift
+++ b/Projects/Feature/RecommendationFeature/Sources/ResultView.swift
@@ -14,7 +14,10 @@ import Utils
 struct ResultView: View {
     let result: RecommendationResult
     @ObservedObject var store: SelectedRestaurantStore
+    @ObservedObject var authStore: AuthSessionStore
     @State private var restaurant: Restaurant?
+    @State private var toastMessage: String?
+    private let backendService = BobPTBackendService()
 
     var body: some View {
         VStack(spacing: 28) {
@@ -59,13 +62,32 @@ struct ResultView: View {
         .background(DesignSystem.Colors.background.ignoresSafeArea())
         .navigationTitle("추천 결과")
         .navigationBarTitleDisplayMode(.inline)
+        .bobPTToast(message: $toastMessage)
         .onAppear {
             guard restaurant == nil, let selected = result.restaurants.randomElement() else {
                 return
             }
 
             restaurant = selected
-            store.insert(selected)
+            if let accessToken = authStore.accessToken {
+                Task {
+                    do {
+                        try await backendService.saveSelection(selected, accessToken: accessToken)
+                    } catch BackendServiceError.unauthorized {
+                        await MainActor.run {
+                            authStore.signOut(message: "로그인이 만료되어 추천 장소를 기기에 저장했습니다.")
+                            store.insert(selected)
+                        }
+                    } catch {
+                        await MainActor.run {
+                            store.insert(selected)
+                            toastMessage = "서버 저장에 실패해 추천 장소를 기기에 저장했습니다."
+                        }
+                    }
+                }
+            } else {
+                store.insert(selected)
+            }
         }
     }
 }

--- a/Projects/Feature/SettingsFeature/Project.swift
+++ b/Projects/Feature/SettingsFeature/Project.swift
@@ -17,7 +17,8 @@ let target: Target = .target(
   dependencies: [
     .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
     .project(target: "BobPTDomain", path: "../../Domain/BobPTDomain"),
-    .project(target: "DesignSystem", path: "../../Shared/DesignSystem")
+    .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),
+    .project(target: "FeedbackUI", path: "../../Shared/FeedbackUI")
   ],
   settings: .targetSettings(product: .staticFramework)
 )

--- a/Projects/Feature/SettingsFeature/Project.swift
+++ b/Projects/Feature/SettingsFeature/Project.swift
@@ -15,6 +15,7 @@ let target: Target = .target(
     "Sources/**"
   ],
   dependencies: [
+    .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
     .project(target: "BobPTDomain", path: "../../Domain/BobPTDomain"),
     .project(target: "DesignSystem", path: "../../Shared/DesignSystem")
   ],

--- a/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 import BobPTCore
 import BobPTDomain
 import DesignSystem
+import FeedbackUI
 
 public struct SettingsView: View {
     @ObservedObject private var authStore: AuthSessionStore
@@ -108,26 +109,9 @@ public struct SettingsView: View {
         .sheet(isPresented: $showsMailComposer) {
             MailComposeView()
         }
-        .alert("메일 계정을 설정해주세요", isPresented: $opensMailSettingsAlert) {
-            Button("확인", role: .cancel) {}
-        }
-        .alert("알림", isPresented: Binding(
-            get: { alertMessage != nil },
-            set: { if !$0 { alertMessage = nil } }
-        )) {
-            Button("확인", role: .cancel) {}
-        } message: {
-            Text(alertMessage ?? "")
-        }
+        .bobPTAlert(title: "메일 계정을 설정해주세요", isPresented: $opensMailSettingsAlert)
+        .bobPTAlert(message: $alertMessage)
         .bobPTToast(message: $toastMessage)
-        .onChange(of: authStore.feedbackMessage) { message in
-            guard let message else {
-                return
-            }
-
-            toastMessage = message
-            authStore.feedbackMessage = nil
-        }
     }
 
     private func handleAppleSignIn(_ result: Result<ASAuthorization, Error>) {

--- a/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
@@ -6,19 +6,65 @@
 //
 
 import MessageUI
+import AuthenticationServices
 import SwiftUI
+import BobPTCore
 import BobPTDomain
 import DesignSystem
 
 public struct SettingsView: View {
+    @ObservedObject private var authStore: AuthSessionStore
     @State private var showsMailComposer = false
     @State private var opensMailSettingsAlert = false
+    @State private var alertMessage: String?
+    @State private var toastMessage: String?
+    @State private var isSigningIn = false
     @AppStorage(DesignSystem.AppearanceMode.storageKey) private var appearanceMode = DesignSystem.AppearanceMode.system
 
-    public init() {}
+    public init(authStore: AuthSessionStore) {
+        self.authStore = authStore
+    }
 
     public var body: some View {
         List {
+            Section("계정") {
+                if let user = authStore.session?.user {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(user.displayName ?? user.email ?? "Apple 계정")
+                            .font(.headline)
+                        Text("로그인됨")
+                            .font(.subheadline)
+                            .foregroundStyle(DesignSystem.Colors.secondaryText)
+                    }
+                    .listRowBackground(DesignSystem.Colors.surface)
+
+                    Button(role: .destructive) {
+                        authStore.signOut(message: "로그아웃되었습니다.")
+                    } label: {
+                        Text("로그아웃")
+                    }
+                    .listRowBackground(DesignSystem.Colors.surface)
+                } else {
+                    ZStack {
+                        SignInWithAppleButton(.continue) { request in
+                            request.requestedScopes = [.fullName, .email]
+                        } onCompletion: { result in
+                            handleAppleSignIn(result)
+                        }
+                        .signInWithAppleButtonStyle(.black)
+                        .opacity(isSigningIn ? 0.35 : 1)
+                        .disabled(isSigningIn)
+
+                        if isSigningIn {
+                            ProgressView()
+                                .tint(.white)
+                        }
+                    }
+                    .frame(height: 44)
+                    .listRowBackground(DesignSystem.Colors.surface)
+                }
+            }
+
             Picker("화면 모드", selection: $appearanceMode) {
                 ForEach(DesignSystem.AppearanceMode.allCases) { mode in
                     Text(mode.title)
@@ -64,6 +110,62 @@ public struct SettingsView: View {
         }
         .alert("메일 계정을 설정해주세요", isPresented: $opensMailSettingsAlert) {
             Button("확인", role: .cancel) {}
+        }
+        .alert("알림", isPresented: Binding(
+            get: { alertMessage != nil },
+            set: { if !$0 { alertMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text(alertMessage ?? "")
+        }
+        .bobPTToast(message: $toastMessage)
+        .onChange(of: authStore.feedbackMessage) { message in
+            guard let message else {
+                return
+            }
+
+            toastMessage = message
+            authStore.feedbackMessage = nil
+        }
+    }
+
+    private func handleAppleSignIn(_ result: Result<ASAuthorization, Error>) {
+        switch result {
+        case .success(let authorization):
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                  let tokenData = credential.identityToken,
+                  let identityToken = String(data: tokenData, encoding: .utf8) else {
+                alertMessage = "Apple 로그인 정보를 확인하지 못했습니다."
+                return
+            }
+
+            let name = PersonNameComponentsFormatter().string(from: credential.fullName ?? PersonNameComponents())
+            isSigningIn = true
+            Task { @MainActor in
+                defer {
+                    isSigningIn = false
+                }
+
+                do {
+                    try await authStore.signInWithApple(
+                        identityToken: identityToken,
+                        fullName: name.isEmpty ? nil : name
+                    )
+                    toastMessage = "로그인되었습니다."
+                } catch let error as BackendServiceError {
+                    alertMessage = error.errorDescription ?? "로그인에 실패했습니다."
+                } catch {
+                    alertMessage = "로그인에 실패했습니다."
+                }
+            }
+        case .failure(let error):
+            if let authorizationError = error as? ASAuthorizationError,
+               authorizationError.code == .canceled {
+                return
+            }
+
+            alertMessage = "Apple 로그인을 완료하지 못했습니다."
         }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/DesignSystem.swift
+++ b/Projects/Shared/DesignSystem/Sources/DesignSystem.swift
@@ -31,55 +31,6 @@ public enum DesignSystem {
     }
 }
 
-public extension View {
-    func bobPTToast(message: Binding<String?>) -> some View {
-        modifier(BobPTToastModifier(message: message))
-    }
-}
-
-private struct BobPTToastModifier: ViewModifier {
-    @Binding var message: String?
-
-    func body(content: Content) -> some View {
-        content
-            .overlay(alignment: .top) {
-                if let message {
-                    Text(message)
-                        .font(.system(size: 14, weight: .semibold))
-                        .multilineTextAlignment(.center)
-                        .foregroundStyle(DesignSystem.Colors.primaryText)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .frame(maxWidth: .infinity)
-                        .background(DesignSystem.Colors.primary)
-                        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.medium, style: .continuous))
-                        .shadow(color: DesignSystem.Colors.shadow, radius: 10, x: 0, y: 5)
-                        .padding(.horizontal, 20)
-                        .padding(.top, 12)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .onTapGesture {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                self.message = nil
-                            }
-                        }
-                }
-            }
-            .animation(.easeOut(duration: 0.22), value: message)
-            .task(id: message) {
-                guard message != nil else {
-                    return
-                }
-
-                try? await Task.sleep(for: .seconds(3))
-                await MainActor.run {
-                    withAnimation(.easeOut(duration: 0.2)) {
-                        self.message = nil
-                    }
-                }
-            }
-    }
-}
-
 private final class DesignSystemBundleToken {}
 
 private extension Color {

--- a/Projects/Shared/DesignSystem/Sources/DesignSystem.swift
+++ b/Projects/Shared/DesignSystem/Sources/DesignSystem.swift
@@ -31,6 +31,55 @@ public enum DesignSystem {
     }
 }
 
+public extension View {
+    func bobPTToast(message: Binding<String?>) -> some View {
+        modifier(BobPTToastModifier(message: message))
+    }
+}
+
+private struct BobPTToastModifier: ViewModifier {
+    @Binding var message: String?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .top) {
+                if let message {
+                    Text(message)
+                        .font(.system(size: 14, weight: .semibold))
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(DesignSystem.Colors.primaryText)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity)
+                        .background(DesignSystem.Colors.primary)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.medium, style: .continuous))
+                        .shadow(color: DesignSystem.Colors.shadow, radius: 10, x: 0, y: 5)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 12)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .onTapGesture {
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                self.message = nil
+                            }
+                        }
+                }
+            }
+            .animation(.easeOut(duration: 0.22), value: message)
+            .task(id: message) {
+                guard message != nil else {
+                    return
+                }
+
+                try? await Task.sleep(for: .seconds(3))
+                await MainActor.run {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        self.message = nil
+                    }
+                }
+            }
+    }
+}
+
 private final class DesignSystemBundleToken {}
 
 private extension Color {

--- a/Projects/Shared/FeedbackUI/Project.swift
+++ b/Projects/Shared/FeedbackUI/Project.swift
@@ -1,8 +1,7 @@
-import DependencyPlugin
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-let targetName = "RecommendationFeature"
+let targetName = "FeedbackUI"
 
 let target: Target = .target(
   name: targetName,
@@ -15,13 +14,7 @@ let target: Target = .target(
     "Sources/**"
   ],
   dependencies: [
-    .project(target: "BobPTCore", path: "../../Core/BobPTCore"),
-    .project(target: "BobPTDomain", path: "../../Domain/BobPTDomain"),
-    .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),
-    .project(target: "FeedbackUI", path: "../../Shared/FeedbackUI"),
-    .project(target: "Utils", path: "../../Shared/Utils"),
-    .SPMTarget.lottie,
-    .SPMTarget.nMapsMap
+    .project(target: "DesignSystem", path: "../DesignSystem")
   ],
   settings: .targetSettings(product: .staticFramework)
 )

--- a/Projects/Shared/FeedbackUI/Sources/FeedbackView.swift
+++ b/Projects/Shared/FeedbackUI/Sources/FeedbackView.swift
@@ -1,0 +1,116 @@
+//
+//  FeedbackView.swift
+//  FeedbackUI
+//
+//  Created by Codex on 5/21/26.
+//
+
+import SwiftUI
+import DesignSystem
+
+public extension View {
+    func bobPTToast(message: Binding<String?>) -> some View {
+        modifier(BobPTToastModifier(message: message))
+    }
+
+    func bobPTAlert(
+        title: String = "알림",
+        message: Binding<String?>,
+        buttonTitle: String = "확인"
+    ) -> some View {
+        modifier(BobPTMessageAlertModifier(title: title, message: message, buttonTitle: buttonTitle))
+    }
+
+    func bobPTAlert(
+        title: String,
+        isPresented: Binding<Bool>,
+        message: String? = nil,
+        buttonTitle: String = "확인"
+    ) -> some View {
+        modifier(BobPTPresentedAlertModifier(
+            title: title,
+            isPresented: isPresented,
+            message: message,
+            buttonTitle: buttonTitle
+        ))
+    }
+}
+
+private struct BobPTToastModifier: ViewModifier {
+    @Binding var message: String?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .top) {
+                if let message {
+                    Text(message)
+                        .font(.system(size: 14, weight: .semibold))
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(DesignSystem.Colors.primaryText)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity)
+                        .background(DesignSystem.Colors.primary)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Radius.medium, style: .continuous))
+                        .shadow(color: DesignSystem.Colors.shadow, radius: 10, x: 0, y: 5)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 12)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .onTapGesture {
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                self.message = nil
+                            }
+                        }
+                }
+            }
+            .animation(.easeOut(duration: 0.22), value: message)
+            .task(id: message) {
+                guard message != nil else {
+                    return
+                }
+
+                try? await Task.sleep(for: .seconds(3))
+                await MainActor.run {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        self.message = nil
+                    }
+                }
+            }
+    }
+}
+
+private struct BobPTMessageAlertModifier: ViewModifier {
+    let title: String
+    @Binding var message: String?
+    let buttonTitle: String
+
+    func body(content: Content) -> some View {
+        content
+            .alert(title, isPresented: Binding(
+                get: { message != nil },
+                set: { if !$0 { message = nil } }
+            )) {
+                Button(buttonTitle, role: .cancel) {}
+            } message: {
+                Text(message ?? "")
+            }
+    }
+}
+
+private struct BobPTPresentedAlertModifier: ViewModifier {
+    let title: String
+    @Binding var isPresented: Bool
+    let message: String?
+    let buttonTitle: String
+
+    func body(content: Content) -> some View {
+        content
+            .alert(title, isPresented: $isPresented) {
+                Button(buttonTitle, role: .cancel) {}
+            } message: {
+                if let message {
+                    Text(message)
+                }
+            }
+    }
+}

--- a/Projects/Shared/Utils/Sources/Extension.swift
+++ b/Projects/Shared/Utils/Sources/Extension.swift
@@ -37,4 +37,8 @@ public extension Bundle {
     var secretKey: String? {
         return infoDictionary?["SECRET_KEY"] as? String
     }
+
+    var apiBaseURL: String? {
+        return infoDictionary?["API_BASE_URL"] as? String
+    }
 }

--- a/Tuist/ProjectDescriptionHelpers/Entitlements.swift
+++ b/Tuist/ProjectDescriptionHelpers/Entitlements.swift
@@ -15,10 +15,9 @@ extension Entitlements {
     /// 앱 타겟에서 사용될 Entitlements 정의
     /// - Note: 애플 로그인, Push Notifications, Keychain Sharing 등 필요한 권한을 이곳에 추가
     public static var app: Entitlements {
-      // 현재는 빈 권한 설정
-      // 필요 시 ["com.apple.developer.applesignin": .boolean(true)] 같은 키들을 추가
-      return .dictionary([:])
-      // 애플로그인, 푸시알림 등등
+      return .dictionary([
+        "com.apple.developer.applesignin": .array([.string("Default")])
+      ])
     }
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/InfoPlist/InfoPlist+BobPT.swift
+++ b/Tuist/ProjectDescriptionHelpers/InfoPlist/InfoPlist+BobPT.swift
@@ -14,6 +14,7 @@ extension InfoPlist {
           "CFBundlePackageType": "APPL",
           "CFBundleShortVersionString": "$(MARKETING_VERSION)",
           "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+          "API_BASE_URL": "$(API_BASE_URL)",
           "ID_KEY": "$(ID_KEY)",
           "ITSAppUsesNonExemptEncryption": false,
           "LSApplicationQueriesSchemes": [

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -10,6 +10,7 @@ let workspace = Workspace(
     "Projects/Core/BobPTCore",
     "Projects/Domain/BobPTDomain",
     "Projects/Shared/DesignSystem",
+    "Projects/Shared/FeedbackUI",
     "Projects/Shared/Utils"
   ],
   additionalFiles: [

--- a/Xcconfig/Sample_Env.xcconfig
+++ b/Xcconfig/Sample_Env.xcconfig
@@ -2,7 +2,7 @@
 // Copy this file to Env.xcconfig and fill in local values.
 
 // Example
-// API_BASE_URL = https://api.example.com
+// API_BASE_URL = https:/$()/tagcloud.synology.me:3000/bobpt
 API_BASE_URL =
 ID_KEY =
 SECRET_KEY =


### PR DESCRIPTION
## 변경 요약
- 로그인/세션 검증 및 API 호출 실패 상황별 alert/toast 피드백을 추가했습니다.
- Toast/Alert 공통 UI를 Shared 하위 FeedbackUI 모듈로 분리했습니다.
- 인증 만료, API 설정 누락, 네트워크/서버 오류, 저장/삭제 실패 흐름에 사용자 피드백을 보강했습니다.

## 주요 화면 변경
- 설정 화면에 로그인/로그아웃 상태와 Apple 로그인 피드백이 추가되었습니다.
- 홈/추천 결과/기록/지도 화면에 상황별 alert 또는 toast가 표시됩니다.
- 스크린샷은 별도 첨부하지 않았습니다.

## 검증
- TUIST_ROOT_DIR=${PWD} TUIST_BUILD_CONFIG=dev tuist generate
- xcodebuild -workspace BobPT.xcworkspace -scheme BobPT_DEV -configuration Debug -destination 'generic/platform=iOS Simulator' build

Close #101