### PR TITLE
[FIX] 소셜 로그인 연동 안정화

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,8 @@ import ProjectDescriptionHelpers
 let packageSettings: PackageSettings = .init(
   productTypes: [
     "Alamofire": .framework,
+    "AppAuth": .framework,
+    "AppAuthCore": .framework,
     "GoogleSignIn": .framework,
     "KakaoSDKAuth": .framework,
     "KakaoSDKCommon": .framework,

--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/SPMTarget.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/SPMTarget.swift
@@ -13,6 +13,8 @@ public extension TargetDependency {
   // Project.swift에서 `.SPMTarget.xxx` 형태로 간단하고 안전하게 가져다 쓸 수 있도록 구성한 파일입니다.
   enum SPMTarget {
     public static let alamofire: TargetDependency = .external(name: "Alamofire")
+    public static let appAuth: TargetDependency = .external(name: "AppAuth")
+    public static let appAuthCore: TargetDependency = .external(name: "AppAuthCore")
     public static let googleSignIn: TargetDependency = .external(name: "GoogleSignIn")
     public static let kakaoSDKAuth: TargetDependency = .external(name: "KakaoSDKAuth")
     public static let kakaoSDKCommon: TargetDependency = .external(name: "KakaoSDKCommon")

--- a/Projects/App/BobPT/Project.swift
+++ b/Projects/App/BobPT/Project.swift
@@ -28,6 +28,8 @@ let appTarget: Target = .target(
     .project(target: "RecommendationFeature", path: "../../Feature/RecommendationFeature"),
     .project(target: "HistoryFeature", path: "../../Feature/HistoryFeature"),
     .project(target: "SettingsFeature", path: "../../Feature/SettingsFeature"),
+    .SPMTarget.appAuth,
+    .SPMTarget.appAuthCore,
     .SPMTarget.googleSignIn,
     .SPMTarget.kakaoSDKAuth,
     .SPMTarget.kakaoSDKCommon

--- a/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
+++ b/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
@@ -67,6 +67,7 @@ public final class AuthSessionStore: ObservableObject {
         idToken: String?,
         authorizationCode: String? = nil,
         redirectURI: String? = nil,
+        state: String? = nil,
         fullName: String? = nil,
         email: String? = nil
     ) async throws {
@@ -76,6 +77,7 @@ public final class AuthSessionStore: ObservableObject {
             idToken: idToken,
             authorizationCode: authorizationCode,
             redirectURI: redirectURI,
+            state: state,
             fullName: fullName,
             email: email
         )
@@ -97,7 +99,7 @@ public final class AuthSessionStore: ObservableObject {
             feedbackMessage = error.errorDescription
         case .networkUnavailable, .serverUnavailable:
             feedbackMessage = error.errorDescription
-        case .forbidden, .notFound, .invalidResponse:
+        case .forbidden, .notFound, .invalidResponse, .message:
             feedbackMessage = "로그인 상태를 확인하지 못했습니다."
         }
     }

--- a/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
+++ b/Projects/Core/BobPTCore/Sources/AuthSessionStore.swift
@@ -11,6 +11,7 @@ import Security
 @MainActor
 public final class AuthSessionStore: ObservableObject {
     @Published public private(set) var session: AuthSession?
+    @Published public private(set) var linkedIdentities: [LinkedSocialIdentity] = []
     @Published public var feedbackMessage: String?
 
     private let backendService: BobPTBackendService
@@ -48,6 +49,7 @@ public final class AuthSessionStore: ObservableObject {
             )
             session = updatedSession
             keychain.save(updatedSession)
+            linkedIdentities = try await backendService.fetchLinkedSocialIdentities(accessToken: accessToken)
         } catch let error as BackendServiceError {
             handleSessionValidationError(error)
         } catch {
@@ -59,6 +61,7 @@ public final class AuthSessionStore: ObservableObject {
         let session = try await backendService.signInWithApple(identityToken: identityToken, fullName: fullName)
         self.session = session
         keychain.save(session)
+        linkedIdentities = try await backendService.fetchLinkedSocialIdentities(accessToken: session.accessToken)
     }
 
     public func signInWithSocial(
@@ -83,10 +86,68 @@ public final class AuthSessionStore: ObservableObject {
         )
         self.session = session
         keychain.save(session)
+        linkedIdentities = try await backendService.fetchLinkedSocialIdentities(accessToken: session.accessToken)
+    }
+
+    public func refreshLinkedIdentities() async throws {
+        guard let accessToken else {
+            linkedIdentities = []
+            return
+        }
+
+        linkedIdentities = try await backendService.fetchLinkedSocialIdentities(accessToken: accessToken)
+    }
+
+    public func linkAppleIdentity(identityToken: String, fullName: String?) async throws {
+        guard let accessToken else {
+            throw BackendServiceError.unauthorized
+        }
+
+        linkedIdentities = try await backendService.linkAppleIdentity(
+            identityToken: identityToken,
+            fullName: fullName,
+            accessToken: accessToken
+        )
+    }
+
+    public func linkSocialIdentity(
+        provider: SocialLoginProvider,
+        accessToken socialAccessToken: String?,
+        idToken: String?,
+        authorizationCode: String? = nil,
+        redirectURI: String? = nil,
+        state: String? = nil,
+        fullName: String? = nil,
+        email: String? = nil
+    ) async throws {
+        guard let accessToken else {
+            throw BackendServiceError.unauthorized
+        }
+
+        linkedIdentities = try await backendService.linkSocialIdentity(
+            provider: provider,
+            accessToken: socialAccessToken,
+            idToken: idToken,
+            authorizationCode: authorizationCode,
+            redirectURI: redirectURI,
+            state: state,
+            fullName: fullName,
+            email: email,
+            currentAccessToken: accessToken
+        )
+    }
+
+    public func unlinkSocialIdentity(provider: AuthProvider) async throws {
+        guard let accessToken else {
+            throw BackendServiceError.unauthorized
+        }
+
+        linkedIdentities = try await backendService.unlinkSocialIdentity(provider: provider, accessToken: accessToken)
     }
 
     public func signOut(message: String? = nil) {
         session = nil
+        linkedIdentities = []
         keychain.delete()
         feedbackMessage = message
     }

--- a/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
+++ b/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
@@ -113,6 +113,90 @@ public struct BobPTBackendService: Sendable {
         return response.data
     }
 
+    public func fetchLinkedSocialIdentities(accessToken: String) async throws -> [LinkedSocialIdentity] {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/identities")
+        let response: APIResponse<[LinkedSocialIdentity]> = try await requestDecodable(
+            endpoint,
+            method: .get,
+            parameters: Optional<EmptyRequest>.none,
+            headers: authorizationHeaders(accessToken: accessToken)
+        )
+
+        return response.data
+    }
+
+    public func linkAppleIdentity(identityToken: String, fullName: String?, accessToken: String) async throws -> [LinkedSocialIdentity] {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/identities/apple")
+        let body = AppleLoginRequest(identityToken: identityToken, fullName: fullName)
+        let response: APIResponse<[LinkedSocialIdentity]> = try await requestDecodable(
+            endpoint,
+            method: .post,
+            parameters: body,
+            headers: authorizationHeaders(accessToken: accessToken)
+        )
+
+        return response.data
+    }
+
+    public func linkSocialIdentity(
+        provider: SocialLoginProvider,
+        accessToken socialAccessToken: String?,
+        idToken: String?,
+        authorizationCode: String? = nil,
+        redirectURI: String? = nil,
+        state: String? = nil,
+        fullName: String? = nil,
+        email: String? = nil,
+        currentAccessToken: String
+    ) async throws -> [LinkedSocialIdentity] {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/identities/\(provider.rawValue)")
+        let body = SocialLoginRequest(
+            accessToken: socialAccessToken,
+            idToken: idToken,
+            authorizationCode: authorizationCode,
+            redirectURI: redirectURI,
+            state: state,
+            fullName: fullName,
+            email: email
+        )
+        let response: APIResponse<[LinkedSocialIdentity]> = try await requestDecodable(
+            endpoint,
+            method: .post,
+            parameters: body,
+            headers: authorizationHeaders(accessToken: currentAccessToken)
+        )
+
+        return response.data
+    }
+
+    public func unlinkSocialIdentity(provider: AuthProvider, accessToken: String) async throws -> [LinkedSocialIdentity] {
+        guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
+            throw BackendServiceError.missingBaseURL
+        }
+
+        let endpoint = baseURL.appendingPathComponent("api/auth/identities/\(provider.rawValue)")
+        let response: APIResponse<[LinkedSocialIdentity]> = try await requestDecodable(
+            endpoint,
+            method: .delete,
+            parameters: Optional<EmptyRequest>.none,
+            headers: authorizationHeaders(accessToken: accessToken)
+        )
+
+        return response.data
+    }
+
     public func fetchSelections(accessToken: String) async throws -> [SavedRestaurant] {
         guard let baseURL = Bundle.main.apiBaseURL.validBaseURL else {
             throw BackendServiceError.missingBaseURL
@@ -288,6 +372,40 @@ public enum SocialLoginProvider: String, CaseIterable, Sendable {
     case kakao
     case naver
     case google
+}
+
+public enum AuthProvider: String, CaseIterable, Codable, Identifiable, Sendable {
+    case apple
+    case kakao
+    case naver
+    case google
+
+    public var id: String {
+        rawValue
+    }
+
+    public var displayName: String {
+        switch self {
+        case .apple:
+            return "Apple"
+        case .kakao:
+            return "카카오"
+        case .naver:
+            return "네이버"
+        case .google:
+            return "Google"
+        }
+    }
+}
+
+public struct LinkedSocialIdentity: Codable, Identifiable, Sendable {
+    public var id: String {
+        provider.rawValue
+    }
+
+    public let provider: AuthProvider
+    public let email: String?
+    public let linkedAt: String
 }
 
 public struct SavedRestaurant: Identifiable, Sendable {

--- a/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
+++ b/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
@@ -56,7 +56,7 @@ public struct BobPTBackendService: Sendable {
                     case .success:
                         continuation.resume()
                     case .failure(let error):
-                        continuation.resume(throwing: error.backendServiceError)
+                        continuation.resume(throwing: error.backendServiceError(responseData: response.data))
                     }
                 }
         }
@@ -85,6 +85,7 @@ public struct BobPTBackendService: Sendable {
         idToken: String?,
         authorizationCode: String? = nil,
         redirectURI: String? = nil,
+        state: String? = nil,
         fullName: String? = nil,
         email: String? = nil
     ) async throws -> AuthSession {
@@ -98,6 +99,7 @@ public struct BobPTBackendService: Sendable {
             idToken: idToken,
             authorizationCode: authorizationCode,
             redirectURI: redirectURI,
+            state: state,
             fullName: fullName,
             email: email
         )
@@ -173,7 +175,7 @@ public struct BobPTBackendService: Sendable {
                 case .success:
                     continuation.resume()
                 case .failure(let error):
-                    continuation.resume(throwing: error.backendServiceError)
+                    continuation.resume(throwing: error.backendServiceError(responseData: response.data))
                 }
             }
         }
@@ -202,7 +204,7 @@ public struct BobPTBackendService: Sendable {
                     case .success:
                         continuation.resume()
                     case .failure(let error):
-                        continuation.resume(throwing: error.backendServiceError)
+                        continuation.resume(throwing: error.backendServiceError(responseData: response.data))
                     }
                 }
         }
@@ -230,7 +232,7 @@ public struct BobPTBackendService: Sendable {
                     case .success(let value):
                         continuation.resume(returning: value)
                     case .failure(let error):
-                        continuation.resume(throwing: error.backendServiceError)
+                        continuation.resume(throwing: error.backendServiceError(responseData: response.data))
                     }
                 }
         }
@@ -245,6 +247,7 @@ public enum BackendServiceError: LocalizedError {
     case serverUnavailable
     case networkUnavailable
     case invalidResponse
+    case message(String)
 
     public var errorDescription: String? {
         switch self {
@@ -262,6 +265,8 @@ public enum BackendServiceError: LocalizedError {
             return "네트워크 연결을 확인해주세요."
         case .invalidResponse:
             return "서버 응답을 처리하지 못했습니다."
+        case .message(let value):
+            return value
         }
     }
 }
@@ -294,6 +299,10 @@ private struct APIResponse<T: Decodable>: Decodable {
     let data: T
 }
 
+private struct APIErrorResponse: Decodable {
+    let message: String?
+}
+
 private struct EmptyRequest: Encodable {}
 
 private struct AppleLoginRequest: Encodable, Sendable {
@@ -306,6 +315,7 @@ private struct SocialLoginRequest: Encodable, Sendable {
     let idToken: String?
     let authorizationCode: String?
     let redirectURI: String?
+    let state: String?
     let fullName: String?
     let email: String?
 }
@@ -379,7 +389,11 @@ private func authorizationHeaders(accessToken: String?) -> HTTPHeaders? {
 }
 
 private extension AFError {
-    var backendServiceError: Error {
+    func backendServiceError(responseData: Data?) -> Error {
+        if let message = responseData?.loginFailureMessage {
+            return BackendServiceError.message(message)
+        }
+
         if let responseCode {
             switch responseCode {
             case 401:
@@ -405,6 +419,18 @@ private extension AFError {
         }
 
         return self
+    }
+}
+
+private extension Data {
+    var loginFailureMessage: String? {
+        guard let errorResponse = try? JSONDecoder().decode(APIErrorResponse.self, from: self),
+              let message = errorResponse.message,
+              message.contains("로그인에 실패") else {
+            return nil
+        }
+
+        return message
     }
 }
 

--- a/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
+++ b/Projects/Core/BobPTCore/Sources/BobPTBackendService.swift
@@ -96,7 +96,8 @@ public struct BobPTBackendService: Sendable {
         let endpoint = baseURL.appendingPathComponent("api/auth/\(provider.rawValue)")
         let body = SocialLoginRequest(
             accessToken: accessToken,
-            idToken: idToken,
+            idToken: provider == .google ? nil : idToken,
+            identityToken: provider == .google ? idToken : nil,
             authorizationCode: authorizationCode,
             redirectURI: redirectURI,
             state: state,
@@ -164,7 +165,8 @@ public struct BobPTBackendService: Sendable {
         let endpoint = baseURL.appendingPathComponent("api/auth/identities/\(provider.rawValue)")
         let body = SocialLoginRequest(
             accessToken: socialAccessToken,
-            idToken: idToken,
+            idToken: provider == .google ? nil : idToken,
+            identityToken: provider == .google ? idToken : nil,
             authorizationCode: authorizationCode,
             redirectURI: redirectURI,
             state: state,
@@ -431,6 +433,7 @@ private struct AppleLoginRequest: Encodable, Sendable {
 private struct SocialLoginRequest: Encodable, Sendable {
     let accessToken: String?
     let idToken: String?
+    let identityToken: String?
     let authorizationCode: String?
     let redirectURI: String?
     let state: String?

--- a/Projects/Feature/SettingsFeature/Project.swift
+++ b/Projects/Feature/SettingsFeature/Project.swift
@@ -19,6 +19,8 @@ let target: Target = .target(
     .project(target: "BobPTDomain", path: "../../Domain/BobPTDomain"),
     .project(target: "DesignSystem", path: "../../Shared/DesignSystem"),
     .project(target: "FeedbackUI", path: "../../Shared/FeedbackUI"),
+    .SPMTarget.appAuth,
+    .SPMTarget.appAuthCore,
     .SPMTarget.googleSignIn,
     .SPMTarget.kakaoSDKAuth,
     .SPMTarget.kakaoSDKUser

--- a/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
@@ -58,6 +58,7 @@ public struct SettingsView: View {
                         Text("로그아웃")
                     }
                     .listRowBackground(DesignSystem.Colors.surface)
+
                 } else {
                     ZStack {
                         SignInWithAppleButton(.continue) { request in
@@ -100,6 +101,15 @@ public struct SettingsView: View {
                     }
                     .disabled(isSigningIn)
                     .listRowBackground(DesignSystem.Colors.surface)
+                }
+            }
+
+            if authStore.isSignedIn {
+                Section("연결된 로그인") {
+                    ForEach(AuthProvider.allCases) { provider in
+                        linkedIdentityRow(provider)
+                            .listRowBackground(DesignSystem.Colors.surface)
+                    }
                 }
             }
 
@@ -158,6 +168,9 @@ public struct SettingsView: View {
         .bobPTAlert(title: "메일 계정을 설정해주세요", isPresented: $opensMailSettingsAlert)
         .bobPTAlert(message: $alertMessage)
         .bobPTToast(message: $toastMessage)
+        .task(id: authStore.isSignedIn) {
+            await refreshLinkedIdentitiesIfNeeded()
+        }
     }
 
 #if DEV
@@ -193,7 +206,65 @@ public struct SettingsView: View {
     }
 #endif
 
-    private func handleAppleSignIn(_ result: Result<ASAuthorization, Error>) {
+    @ViewBuilder
+    private func linkedIdentityRow(_ provider: AuthProvider) -> some View {
+        let isLinked = authStore.linkedIdentities.contains { $0.provider == provider }
+
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Label(provider.displayName, systemImage: provider.systemImageName)
+                    .font(.body)
+
+                Text(isLinked ? "연결됨" : "연결 안 됨")
+                    .font(.caption)
+                    .foregroundStyle(DesignSystem.Colors.secondaryText)
+            }
+
+            Spacer()
+
+            if isLinked {
+                Button(role: .destructive) {
+                    unlinkIdentity(provider)
+                } label: {
+                    Text("해제")
+                }
+                .disabled(isSigningIn)
+            } else if provider == .apple {
+                SignInWithAppleButton(.continue) { request in
+                    request.requestedScopes = [.fullName, .email]
+                } onCompletion: { result in
+                    handleAppleSignIn(result, mode: .link)
+                }
+                .signInWithAppleButtonStyle(.black)
+                .frame(width: 112, height: 36)
+                .disabled(isSigningIn)
+            } else {
+                Button {
+                    linkIdentity(provider)
+                } label: {
+                    Text("연결")
+                }
+                .disabled(isSigningIn)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func refreshLinkedIdentitiesIfNeeded() async {
+        guard authStore.isSignedIn else {
+            return
+        }
+
+        do {
+            try await authStore.refreshLinkedIdentities()
+        } catch let error as BackendServiceError {
+            alertMessage = error.errorDescription ?? "연결된 로그인 정보를 불러오지 못했습니다."
+        } catch {
+            alertMessage = "연결된 로그인 정보를 불러오지 못했습니다."
+        }
+    }
+
+    private func handleAppleSignIn(_ result: Result<ASAuthorization, Error>, mode: SocialAuthMode = .signIn) {
         switch result {
         case .success(let authorization):
             guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
@@ -211,15 +282,22 @@ public struct SettingsView: View {
                 }
 
                 do {
-                    try await authStore.signInWithApple(
-                        identityToken: identityToken,
-                        fullName: name.isEmpty ? nil : name
-                    )
-                    toastMessage = "로그인되었습니다."
+                    if mode == .signIn {
+                        try await authStore.signInWithApple(
+                            identityToken: identityToken,
+                            fullName: name.isEmpty ? nil : name
+                        )
+                    } else {
+                        try await authStore.linkAppleIdentity(
+                            identityToken: identityToken,
+                            fullName: name.isEmpty ? nil : name
+                        )
+                    }
+                    toastMessage = mode.successMessage
                 } catch let error as BackendServiceError {
-                    alertMessage = error.errorDescription ?? "로그인에 실패했습니다."
+                    alertMessage = error.errorDescription ?? mode.failureMessage
                 } catch {
-                    alertMessage = "로그인에 실패했습니다."
+                    alertMessage = mode.failureMessage
                 }
             }
         case .failure(let error):
@@ -232,7 +310,7 @@ public struct SettingsView: View {
         }
     }
 
-    private func handleKakaoSignIn() {
+    private func handleKakaoSignIn(mode: SocialAuthMode = .signIn) {
         isSigningIn = true
 
         let isKakaoTalkAvailable = UserApi.isKakaoTalkLoginAvailable()
@@ -277,7 +355,7 @@ public struct SettingsView: View {
                         "accessTokenSuffix": String(accessToken.suffix(6))
                     ]
                 )
-                await completeSocialSignIn(provider: .kakao, accessToken: accessToken, idToken: oauthToken?.idToken)
+                await completeSocialAuthentication(provider: .kakao, accessToken: accessToken, idToken: oauthToken?.idToken, mode: mode)
             }
         }
 
@@ -288,7 +366,7 @@ public struct SettingsView: View {
         }
     }
 
-    private func handleNaverSignIn() {
+    private func handleNaverSignIn(mode: SocialAuthMode = .signIn) {
         guard let clientId = Bundle.main.socialLoginValue(for: "NAVER_LOGIN_CLIENT_ID"),
               let urlScheme = Bundle.main.socialLoginValue(for: "NAVER_LOGIN_URL_SCHEME") else {
             alertMessage = "네이버 로그인 설정이 필요합니다."
@@ -330,13 +408,14 @@ public struct SettingsView: View {
                     return
                 }
 
-                await completeSocialSignIn(
+                await completeSocialAuthentication(
                     provider: .naver,
                     accessToken: nil,
                     idToken: nil,
                     authorizationCode: authorizationCode,
                     redirectURI: redirectURI,
-                    state: state
+                    state: state,
+                    mode: mode
                 )
             }
         }
@@ -346,7 +425,7 @@ public struct SettingsView: View {
         session.start()
     }
 
-    private func handleGoogleSignIn() {
+    private func handleGoogleSignIn(mode: SocialAuthMode = .signIn) {
         guard let presentingViewController = UIApplication.shared.rootViewController else {
             alertMessage = "로그인 화면을 열 수 없습니다."
             return
@@ -367,18 +446,19 @@ public struct SettingsView: View {
                     return
                 }
 
-                await completeSocialSignIn(
+                await completeSocialAuthentication(
                     provider: .google,
                     accessToken: user.accessToken.tokenString,
                     idToken: user.idToken?.tokenString,
                     fullName: user.profile?.name,
-                    email: user.profile?.email
+                    email: user.profile?.email,
+                    mode: mode
                 )
             }
         }
     }
 
-    private func completeSocialSignIn(
+    private func completeSocialAuthentication(
         provider: SocialLoginProvider,
         accessToken: String?,
         idToken: String?,
@@ -386,28 +466,111 @@ public struct SettingsView: View {
         redirectURI: String? = nil,
         state: String? = nil,
         fullName: String? = nil,
-        email: String? = nil
+        email: String? = nil,
+        mode: SocialAuthMode = .signIn
     ) async {
         defer {
             isSigningIn = false
         }
 
         do {
-            try await authStore.signInWithSocial(
-                provider: provider,
-                accessToken: accessToken,
-                idToken: idToken,
-                authorizationCode: authorizationCode,
-                redirectURI: redirectURI,
-                state: state,
-                fullName: fullName,
-                email: email
-            )
-            toastMessage = "로그인되었습니다."
+            if mode == .signIn {
+                try await authStore.signInWithSocial(
+                    provider: provider,
+                    accessToken: accessToken,
+                    idToken: idToken,
+                    authorizationCode: authorizationCode,
+                    redirectURI: redirectURI,
+                    state: state,
+                    fullName: fullName,
+                    email: email
+                )
+            } else {
+                try await authStore.linkSocialIdentity(
+                    provider: provider,
+                    accessToken: accessToken,
+                    idToken: idToken,
+                    authorizationCode: authorizationCode,
+                    redirectURI: redirectURI,
+                    state: state,
+                    fullName: fullName,
+                    email: email
+                )
+            }
+            toastMessage = mode.successMessage
         } catch let error as BackendServiceError {
-            alertMessage = error.errorDescription ?? "로그인에 실패했습니다."
+            alertMessage = error.errorDescription ?? mode.failureMessage
         } catch {
-            alertMessage = "로그인에 실패했습니다."
+            alertMessage = mode.failureMessage
+        }
+    }
+
+    private func linkIdentity(_ provider: AuthProvider) {
+        switch provider {
+        case .apple:
+            return
+        case .kakao:
+            handleKakaoSignIn(mode: .link)
+        case .naver:
+            handleNaverSignIn(mode: .link)
+        case .google:
+            handleGoogleSignIn(mode: .link)
+        }
+    }
+
+    private func unlinkIdentity(_ provider: AuthProvider) {
+        isSigningIn = true
+        Task { @MainActor in
+            defer {
+                isSigningIn = false
+            }
+
+            do {
+                try await authStore.unlinkSocialIdentity(provider: provider)
+                toastMessage = "연결을 해제했습니다."
+            } catch let error as BackendServiceError {
+                alertMessage = error.errorDescription ?? "연결 해제에 실패했습니다."
+            } catch {
+                alertMessage = "연결 해제에 실패했습니다."
+            }
+        }
+    }
+}
+
+private enum SocialAuthMode {
+    case signIn
+    case link
+
+    var successMessage: String {
+        switch self {
+        case .signIn:
+            return "로그인되었습니다."
+        case .link:
+            return "계정을 연결했습니다."
+        }
+    }
+
+    var failureMessage: String {
+        switch self {
+        case .signIn:
+            return "로그인에 실패했습니다."
+        case .link:
+            return "계정 연결에 실패했습니다."
+        }
+    }
+}
+
+private extension AuthProvider {
+    var systemImageName: String {
+        switch self {
+        case .apple:
+            return "apple.logo"
+        case .kakao:
+            return "message.fill"
+        case .naver:
+            return "n.circle.fill"
+        case .google:
+            return "g.circle.fill"
         }
     }
 }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
@@ -335,7 +335,8 @@ public struct SettingsView: View {
                     accessToken: nil,
                     idToken: nil,
                     authorizationCode: authorizationCode,
-                    redirectURI: redirectURI
+                    redirectURI: redirectURI,
+                    state: state
                 )
             }
         }
@@ -383,6 +384,7 @@ public struct SettingsView: View {
         idToken: String?,
         authorizationCode: String? = nil,
         redirectURI: String? = nil,
+        state: String? = nil,
         fullName: String? = nil,
         email: String? = nil
     ) async {
@@ -397,6 +399,7 @@ public struct SettingsView: View {
                 idToken: idToken,
                 authorizationCode: authorizationCode,
                 redirectURI: redirectURI,
+                state: state,
                 fullName: fullName,
                 email: email
             )


### PR DESCRIPTION
## 변경 요약
- 네이버 로그인 인증 코드 처리와 Google 로그인 토큰 전달 방식을 수정했습니다.
- 소셜 계정 연결/해제 UI와 백엔드 연동을 추가했습니다.
- GoogleSignIn 런타임 의존성인 AppAuth/AppAuthCore 연결을 보강했습니다.

## 검증
- xcodebuild -workspace BobPT.xcworkspace -scheme BobPT_DEV -configuration DEV -sdk iphonesimulator -destination generic/platform=iOS Simulator build
- Kakao/Naver/Google 로그인 수동 확인

Related to: #103