### PR TITLE
[FIX] Tuist 설치 rate limit 오류 수정

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -122,6 +122,8 @@ jobs:
           bundler-cache: true
 
       - name: Set up Tuist
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           brew install mise
           echo "$HOME/.local/share/mise/shims" >> "$GITHUB_PATH"


### PR DESCRIPTION
## 변경 요약
- Fastlane Deploy 워크플로의 `Set up Tuist` 단계에 `GITHUB_TOKEN`을 전달합니다.
- `mise install`이 Tuist 릴리즈 조회 중 GitHub unauthenticated rate limit에 걸리지 않도록 수정합니다.

## 검증
- fastlane-deploy.yml YAML 파싱 확인

Fix: #107