### PR TITLE
[FIX] Apple 로그인 capability 설정 보강

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,20 @@ platform :ios do
       UI.message("Sign in with Apple capability is already enabled for #{bundle_id}")
     else
       UI.message("Enabling Sign in with Apple capability for #{bundle_id}")
-      bundle.create_capability(capability_type)
+      bundle.update_capability(
+        capability_type,
+        enabled: true,
+        settings: [
+          {
+            key: Spaceship::ConnectAPI::BundleIdCapability::Settings::APPLE_ID_AUTH_APP_CONSENT,
+            options: [
+              {
+                key: Spaceship::ConnectAPI::BundleIdCapability::Options::PRIMARY_APP_CONSENT
+              }
+            ]
+          }
+        ]
+      )
     end
   end
 


### PR DESCRIPTION
## 변경 요약
- Sign in with Apple capability 활성화 시 Primary App 설정을 함께 전달합니다.
- App Store Connect API의 capability configuration 요구사항을 반영했습니다.

## 검증
- Fastfile Ruby syntax 확인

Related to: #107