### PR TITLE
[FIX] 자동 배포 실행 조건 제한

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy app
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (vars.ENABLE_AUTO_DEPLOY == '1' && github.event.pull_request.merged == true)
     runs-on: macos-26
     timeout-minutes: 60
 


### PR DESCRIPTION
## 변경 요약
- PR 머지 후 자동 배포는 `ENABLE_AUTO_DEPLOY=1` repo variable이 켜진 경우에만 실행하도록 제한했습니다.
- Apple Developer Portal의 Sign in with Apple capability 설정 전까지 dev 머지 워크플로가 배포 단계에서 실패하지 않게 합니다.
- 수동 배포는 기존처럼 `workflow_dispatch`로 실행할 수 있습니다.

## 검증
- fastlane-deploy.yml YAML 파싱 확인

Related to: #107