### PR TITLE
[FIX] Fastlane 자동 배포 조건 복원

### DIFF
--- a/.github/workflows/fastlane-deploy.yml
+++ b/.github/workflows/fastlane-deploy.yml
@@ -37,13 +37,13 @@ permissions:
 jobs:
   deploy:
     name: Deploy app
-    if: github.event_name == 'workflow_dispatch' || (vars.ENABLE_AUTO_DEPLOY == '1' && github.event.pull_request.merged == true)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: macos-26
     timeout-minutes: 60
 
     env:
       DEPLOY_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_target || (github.base_ref == 'dev' && 'testflight' || 'app_store_prepare') }}
-      TUIST_BUILD_CONFIG: ${{ github.event_name == 'workflow_dispatch' && inputs.build_config || (github.base_ref == 'dev' && 'BETA' || 'RELEASE') }}
+      TUIST_BUILD_CONFIG: ${{ github.event_name == 'workflow_dispatch' && inputs.build_config || 'RELEASE' }}
       API_BASE_URL: ${{ secrets.API_BASE_URL }}
       ID_KEY: ${{ secrets.ID_KEY }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}


### PR DESCRIPTION
## 변경 요약
- PR 머지 시 Fastlane Deploy가 자동 실행되도록 조건을 복원했습니다.
- 자동 실행의 기본 `TUIST_BUILD_CONFIG`를 `RELEASE`로 복원했습니다.
- 기존 의도대로 dev 머지는 RELEASE 기반 TestFlight, main 머지는 RELEASE 기반 App Store 준비로 분기됩니다.
- Tuist 설치 rate limit 방지를 위한 `GITHUB_TOKEN` 주입은 유지했습니다.

## 검증
- fastlane-deploy.yml YAML 파싱 확인

Related to: #114